### PR TITLE
Store the version of key addressing used in each TableDescriptor

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -45,7 +45,8 @@ func testTableDesc() *TableDescriptor {
 			Name: "primary", Unique: true, ColumnNames: []string{"a"},
 			ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 		},
-		Privileges: NewDefaultPrivilegeDescriptor(),
+		Privileges:           NewDefaultPrivilegeDescriptor(),
+		KeyAddressingVersion: KeyAddressingVersion1,
 	}
 }
 

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -43,6 +43,19 @@ type IndexID uint32
 // DescriptorVersion is a custom type for TableDescriptor Versions.
 type DescriptorVersion uint32
 
+// KeyAddressingVersion is a custom type for TableDescriptor key addressing
+// versions.
+type KeyAddressingVersion uint32
+
+const (
+	// KeyAddressingVersionInvalid may be used as a sential value to indicate a table
+	// encoding that is never valid.
+	KeyAddressingVersionInvalid KeyAddressingVersion = 0
+	// KeyAddressingVersion1 corresponds to the encoding described in
+	// https://www.cockroachlabs.com/blog/sql-in-cockroachdb-mapping-table-data-to-key-value-storage/.
+	KeyAddressingVersion1 KeyAddressingVersion = 1
+)
+
 // MutationID is custom type for TableDescriptor mutations.
 type MutationID uint32
 
@@ -469,6 +482,11 @@ func (desc *TableDescriptor) Validate() error {
 			}
 		}
 	}
+
+	if desc.GetKeyAddressingVersion() != KeyAddressingVersion1 {
+		return fmt.Errorf("table %q is encoded using using a version that is unsupported by this client", desc.Name)
+	}
+
 	// Validate the privilege descriptor.
 	return desc.Privileges.Validate(desc.GetID())
 }

--- a/sql/structured.pb.go
+++ b/sql/structured.pb.go
@@ -453,6 +453,9 @@ type TableDescriptor struct {
 	Lease     *TableDescriptor_SchemaChangeLease `protobuf:"bytes,15,opt,name=lease" json:"lease,omitempty"`
 	// An id for the next group of mutations to be applied together.
 	NextMutationID MutationID `protobuf:"varint,16,opt,name=next_mutation_id,casttype=MutationID" json:"next_mutation_id"`
+	// key_addressing_version declares which sql to key:value mapping is being
+	// used to represent the data in this table.
+	KeyAddressingVersion KeyAddressingVersion `protobuf:"varint,17,opt,name=key_addressing_version,casttype=KeyAddressingVersion" json:"key_addressing_version"`
 }
 
 func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
@@ -560,6 +563,13 @@ func (m *TableDescriptor) GetLease() *TableDescriptor_SchemaChangeLease {
 func (m *TableDescriptor) GetNextMutationID() MutationID {
 	if m != nil {
 		return m.NextMutationID
+	}
+	return 0
+}
+
+func (m *TableDescriptor) GetKeyAddressingVersion() KeyAddressingVersion {
+	if m != nil {
+		return m.KeyAddressingVersion
 	}
 	return 0
 }
@@ -1077,6 +1087,11 @@ func (m *TableDescriptor) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x1
 	i++
 	i = encodeVarintStructured(data, i, uint64(m.NextMutationID))
+	data[i] = 0x88
+	i++
+	data[i] = 0x1
+	i++
+	i = encodeVarintStructured(data, i, uint64(m.KeyAddressingVersion))
 	return i, nil
 }
 
@@ -1354,6 +1369,7 @@ func (m *TableDescriptor) Size() (n int) {
 		n += 1 + l + sovStructured(uint64(l))
 	}
 	n += 2 + sovStructured(uint64(m.NextMutationID))
+	n += 2 + sovStructured(uint64(m.KeyAddressingVersion))
 	return n
 }
 
@@ -2538,6 +2554,25 @@ func (m *TableDescriptor) Unmarshal(data []byte) error {
 				b := data[iNdEx]
 				iNdEx++
 				m.NextMutationID |= (MutationID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 17:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KeyAddressingVersion", wireType)
+			}
+			m.KeyAddressingVersion = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStructured
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.KeyAddressingVersion |= (KeyAddressingVersion(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -245,6 +245,11 @@ message TableDescriptor {
   // An id for the next group of mutations to be applied together.
   optional uint32 next_mutation_id = 16 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextMutationID", (gogoproto.casttype) = "MutationID"];
+
+  // key_addressing_version declares which sql to key:value mapping is being
+  // used to represent the data in this table.
+  optional uint32 key_addressing_version = 17 [(gogoproto.nullable) = false,
+      (gogoproto.casttype) = "KeyAddressingVersion"];
 }
 
 // DatabaseDescriptor represents a namespace (aka database) and is stored

--- a/sql/structured_test.go
+++ b/sql/structured_test.go
@@ -57,7 +57,8 @@ func TestAllocateIDs(t *testing.T) {
 			makeIndexDescriptor("d", []string{"b", "a"}),
 			makeIndexDescriptor("e", []string{"b"}),
 		},
-		Privileges: sql.NewDefaultPrivilegeDescriptor(),
+		Privileges:           sql.NewDefaultPrivilegeDescriptor(),
+		KeyAddressingVersion: sql.KeyAddressingVersion1,
 	}
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
@@ -86,10 +87,11 @@ func TestAllocateIDs(t *testing.T) {
 				ColumnDirections:  []sql.IndexDescriptor_Direction{sql.IndexDescriptor_ASC},
 				ImplicitColumnIDs: []sql.ColumnID{1}},
 		},
-		Privileges:     sql.NewDefaultPrivilegeDescriptor(),
-		NextColumnID:   4,
-		NextIndexID:    4,
-		NextMutationID: 1,
+		Privileges:           sql.NewDefaultPrivilegeDescriptor(),
+		NextColumnID:         4,
+		NextIndexID:          4,
+		NextMutationID:       1,
+		KeyAddressingVersion: sql.KeyAddressingVersion1,
 	}
 	if !reflect.DeepEqual(expected, desc) {
 		a, _ := json.MarshalIndent(expected, "", "  ")
@@ -330,6 +332,22 @@ func TestValidateTableDesc(t *testing.T) {
 				PrimaryIndex: sql.IndexDescriptor{ID: 1, Name: "bar", ColumnIDs: []sql.ColumnID{1},
 					ColumnNames: []string{"blah"},
 				},
+				NextColumnID: 2,
+				NextIndexID:  2,
+			}},
+		{`table "foo" is encoded using using a version that is unsupported by this client`,
+			sql.TableDescriptor{
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
+				Columns: []sql.ColumnDescriptor{
+					{ID: 1, Name: "bar"},
+				},
+				PrimaryIndex: sql.IndexDescriptor{
+					ID: 1, Name: "primary", ColumnIDs: []sql.ColumnID{1}, ColumnNames: []string{"bar"},
+					ColumnDirections: []sql.IndexDescriptor_Direction{sql.IndexDescriptor_ASC},
+				},
+
 				NextColumnID: 2,
 				NextIndexID:  2,
 			}},

--- a/sql/table.go
+++ b/sql/table.go
@@ -63,6 +63,7 @@ func makeTableDesc(p *parser.CreateTable, parentID ID) (TableDescriptor, error) 
 	}
 	desc.Name = p.Table.Table()
 	desc.ParentID = parentID
+	desc.KeyAddressingVersion = KeyAddressingVersion1
 	// We don't use version 0.
 	desc.Version = 1
 


### PR DESCRIPTION
Check it when the table is used. For now, just error out when they don't match exactly.

Fixes 4994.
